### PR TITLE
Add support for app logos

### DIFF
--- a/vizydrop/rest/handlers.py
+++ b/vizydrop/rest/handlers.py
@@ -1,9 +1,11 @@
 from .base import BaseHandler
+from .logo import LogoHandler
 from .account import AccountValidationHandler, OAuth1AccountHandler, OAuth2AccountHandler
 from .filter import FilterDatalistHandler
 
 rest_handlers = [
     (r'^/?$', BaseHandler),
+    (r'^/logo/?$', LogoHandler),
     (r'^/datalist/?$', FilterDatalistHandler),
     (r'^/oauth1/?$', OAuth1AccountHandler),
     (r'^/oauth2/?$', OAuth2AccountHandler),

--- a/vizydrop/rest/logo.py
+++ b/vizydrop/rest/logo.py
@@ -1,0 +1,23 @@
+from os import path
+
+from vizydrop.rest import VizydropAppRequestHandler
+from . import TpaHandlerMixin
+
+
+class LogoHandler(VizydropAppRequestHandler, TpaHandlerMixin):
+    def get(self):
+        # check for a local file
+        d = path.dirname(path.realpath(self.tpa.__file__))
+        fp = path.join(d, 'logo.svg')
+        if path.isfile(fp):
+            self.set_header('Content-Type', 'image/svg+xml')
+            with open(fp, 'r') as fh:
+                return self.write(fh.read())
+        # check our meta
+        meta = self.tpa.Meta
+        if hasattr(meta, 'logo'):
+            # use our logo specified in our meta
+            self.set_status(303)
+            return self.set_header('Location', meta.logo)
+        # and finally, if we have nothing...
+        self.set_status(204)

--- a/vizydrop/rest/logo.py
+++ b/vizydrop/rest/logo.py
@@ -1,5 +1,5 @@
 from os import path
-
+import inspect
 from vizydrop.rest import VizydropAppRequestHandler
 from . import TpaHandlerMixin
 
@@ -7,7 +7,7 @@ from . import TpaHandlerMixin
 class LogoHandler(VizydropAppRequestHandler, TpaHandlerMixin):
     def get(self):
         # check for a local file
-        d = path.dirname(path.realpath(self.tpa.__file__))
+        d = path.dirname(path.realpath(inspect.getfile(self.tpa)))
         fp = path.join(d, 'logo.svg')
         if path.isfile(fp):
             self.set_header('Content-Type', 'image/svg+xml')

--- a/vizydrop/rest/logo.py
+++ b/vizydrop/rest/logo.py
@@ -21,3 +21,4 @@ class LogoHandler(VizydropAppRequestHandler, TpaHandlerMixin):
             return self.set_header('Location', meta.logo)
         # and finally, if we have nothing...
         self.set_status(204)
+        return self.finish(encode=False)


### PR DESCRIPTION
An app's `Meta.logo` may be a URL to a SVG _or_ a `logo.svg` file can be put in the same directory as the app's main class.  The SDK will look first for the URL, then for the local file, before resorting to a default application logo.
