### PR TITLE
Move token refreshes to apps

### DIFF
--- a/vizydrop/__init__.py
+++ b/vizydrop/__init__.py
@@ -1,2 +1,2 @@
 __author__ = 'jonathan'
-__version__ = '0.4.4'
+__version__ = '0.5.0'

--- a/vizydrop/rest/__init__.py
+++ b/vizydrop/rest/__init__.py
@@ -72,7 +72,7 @@ class VizydropAppRequestHandler(RequestHandler):
             except AttributeError:
                 pass
         log.app_log.error("Error: {}\n{}".format(msg, "".join(format_tb(tb))))
-        self.finish(json.dumps({"exception": typ.__name__, "message": str(exc), 'traceback': format_tb(tb, None)}))
+        self.finish(json.dumps({"error": str(exc)}))
 
     def finish(self, chunk=None, encode=True):
         if not isinstance(chunk, str) and encode is True:

--- a/vizydrop/sdk/account.py
+++ b/vizydrop/sdk/account.py
@@ -180,7 +180,7 @@ class AppOAuthv2Account(AppOAuthAccount):
         raise NotImplementedError
 
     @gen.coroutine
-    def refresh_token(self):
+    def do_token_refresh(self):
         # check refreshes
         if hasattr(self, 'refresh_token'):
             try:

--- a/vizydrop/sdk/account.py
+++ b/vizydrop/sdk/account.py
@@ -202,7 +202,6 @@ class AppOAuthv2Account(AppOAuthAccount):
                     self.token_expiration = datetime.now() + timedelta(seconds=int(response_data.get('expires_in')))
                     if 'refresh_token' in response_data.keys():
                         self.refresh_token = response_data.get('refresh_token')
-                    yield self.save()
                     log.app_log.info("Token refreshed successfully!")
                 except HTTPError as e:
                     log.app_log.error("Error refreshing token {} ({})".format(self._id, e.readlines()))

--- a/vizydrop/sdk/account.py
+++ b/vizydrop/sdk/account.py
@@ -183,13 +183,8 @@ class AppOAuthv2Account(AppOAuthAccount):
     def do_token_refresh(self):
         # check refreshes
         if hasattr(self, 'refresh_token'):
-            try:
-                expiration = datetime.strptime(self.token_expiration, '%Y-%m-%dT%H:%M:%S.%f')
-            except ValueError:
-                log.app_log.error("Unable to parse token_expiration for account {}".format(self._id))
-                return False, "unable to parse expiration"
             # and actually refresh if we need it
-            if expiration < datetime.now():
+            if self.token_expiration < datetime.now():
                 log.app_log.info("Refreshing token for account {}".format(self._id))
                 try:
                     uri, headers, body = self.get_client().prepare_refresh_token_request(self.Meta.token_uri,

--- a/vizydrop/sdk/account.py
+++ b/vizydrop/sdk/account.py
@@ -192,7 +192,7 @@ class AppOAuthv2Account(AppOAuthAccount):
                                                                                          client_secret=self.Meta.client_secret,
                                                                                          refresh_token=self.refresh_token)
 
-                    token_request = HTTPRequest(uri, data=body.encode('utf-8'), headers=headers, method='POST')
+                    token_request = HTTPRequest(uri, body=body.encode('utf-8'), headers=headers, method='POST')
                     client = AsyncHTTPClient()
                     response = yield client.fetch(token_request)
 


### PR DESCRIPTION
Refreshes for apps should occur in the `validate` function within each account.  Helper `do_token_refresh` is in place to do this if `refresh_token` and `token_expiration` contain the appropriate values.
